### PR TITLE
Tag Conferences

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "2.2.2"
 
 gem "active_model_serializers", "0.8.3"
+gem "acts-as-taggable-on"
 gem "autoprefixer-rails"
 gem "bourbon", "~> 4.2.0"
 gem "coffee-rails", "~> 4.1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (3.5.0)
+      activerecord (>= 3.2, < 5)
     addressable (2.3.8)
     arel (6.0.0)
     autoprefixer-rails (5.1.10)
@@ -297,6 +299,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (= 0.8.3)
+  acts-as-taggable-on
   autoprefixer-rails
   awesome_print
   bourbon (~> 4.2.0)

--- a/app/controllers/api/v1/conferences_controller.rb
+++ b/app/controllers/api/v1/conferences_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ConferencesController < ApplicationController
   def index
-    @conferences = RubyConference.upcoming
+    @conferences = Conference.tagged_with("ruby").upcoming
 
     render(
       json: @conferences,

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -1,4 +1,6 @@
 class Conference < ActiveRecord::Base
+  acts_as_taggable
+
   validates :name, presence: true
   validates :location, presence: true
   validates :twitter_username, presence: true
@@ -6,7 +8,6 @@ class Conference < ActiveRecord::Base
   validates :website, presence: true
   validates :start_date, presence: true
   validates :end_date, presence: true
-  validates :type, presence: true
 
   def self.upcoming
     where("start_date >= ?", Date.today).order("start_date")

--- a/app/models/js_conference.rb
+++ b/app/models/js_conference.rb
@@ -1,2 +1,0 @@
-class JsConference < Conference
-end

--- a/app/models/ruby_conference.rb
+++ b/app/models/ruby_conference.rb
@@ -1,2 +1,0 @@
-class RubyConference < Conference
-end

--- a/db/migrate/20150618142313_remove_type_from_conferences.rb
+++ b/db/migrate/20150618142313_remove_type_from_conferences.rb
@@ -1,0 +1,5 @@
+class RemoveTypeFromConferences < ActiveRecord::Migration
+  def change
+    remove_column :conferences, :type, :string
+  end
+end

--- a/db/migrate/20150619095343_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20150619095343_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,31 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20150619095344_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20150619095344_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20150619095345_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20150619095345_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20150619095346_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20150619095346_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20150619095347_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20150619095347_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150614163801) do
+ActiveRecord::Schema.define(version: 20150619095347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 20150614163801) do
     t.date     "start_date",       null: false
     t.date     "end_date",         null: false
     t.string   "website",          null: false
-    t.string   "type",             null: false
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -59,5 +58,25 @@ ActiveRecord::Schema.define(version: 20150614163801) do
     t.datetime "updated_at",      null: false
     t.integer  "conference_type", null: false
   end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id"
+    t.integer  "taggable_id"
+    t.string   "taggable_type"
+    t.integer  "tagger_id"
+    t.string   "tagger_type"
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
+  end
+
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+
+  create_table "tags", force: :cascade do |t|
+    t.string  "name"
+    t.integer "taggings_count", default: 0
+  end
+
+  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,16 +2,17 @@ require 'net/http'
 require 'uri'
 
 conferences = YAML.load(File.read("#{Rails.root}/db/rubyconferences.yml"))
-RubyConference.delete_all
+Conference.delete_all
 
 conferences.each do |attributes|
-  conference = RubyConference.new
+  conference = Conference.new
   conference.name = attributes["name"]
   conference.location = attributes["location"]
   conference.website = attributes["website"]
   conference.twitter_username = attributes["twitter_username"]
   conference.start_date = Date.parse(attributes["start_date"])
   conference.end_date = Date.parse(attributes["end_date"])
+  conference.tag_list = "ruby"
 
   twitter_image_url = URI(
     "https://twitter.com/#{attributes["twitter_username"]}/profile_image?size=bigger"

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -7,11 +7,5 @@ FactoryGirl.define do
     twitter_username "twiiter"
     image_url "image_url"
     website "foo.bar"
-
-    factory :ruby_conference, class: "RubyConference" do
-    end
-
-    factory :js_conference, class: "JsConference" do
-    end
   end
 end

--- a/spec/models/conference_spec.rb
+++ b/spec/models/conference_spec.rb
@@ -8,20 +8,19 @@ RSpec.describe Conference, :type => :model do
   it { should validate_presence_of(:website) }
   it { should validate_presence_of(:start_date) }
   it { should validate_presence_of(:end_date) }
-  it { should validate_presence_of(:type) }
 
   describe ".upcoming" do
     it "returns upcoming Conferences based on start date" do
-      create(:ruby_conference, start_date: Date.yesterday)
-      later_conference = create(:ruby_conference, start_date: Date.today)
+      create(:conference, start_date: Date.yesterday)
+      later_conference = create(:conference, start_date: Date.today)
 
       expect(Conference.upcoming).to eq([later_conference])
     end
 
     it "orders Conferences based on start date" do
-      todays_conference = create(:ruby_conference, start_date: Date.today)
+      todays_conference = create(:conference, start_date: Date.today)
       later_conference = create(
-        :ruby_conference,
+        :conference,
         start_date: Date.today + 1.day
       )
 
@@ -31,16 +30,16 @@ RSpec.describe Conference, :type => :model do
 
   describe ".past" do
     it "returns past Conferences based on start date" do
-      old_conference = create(:ruby_conference, start_date: Date.yesterday)
-      create(:ruby_conference, start_date: Date.today)
+      old_conference = create(:conference, start_date: Date.yesterday)
+      create(:conference, start_date: Date.today)
 
       expect(Conference.past).to eq([old_conference])
     end
 
     it "orders Conferences based on start date" do
-      old_conference = create(:ruby_conference, start_date: Date.yesterday)
+      old_conference = create(:conference, start_date: Date.yesterday)
       very_old_conference = create(
-        :ruby_conference,
+        :conference,
         start_date: Date.yesterday - 10.day
       )
 


### PR DESCRIPTION
- We can categories Conferences based on tags. 
- By default `api/v1/conferences/` is Ruby tagged conferences.
