### PR TITLE
Add ability to not having an API token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,10 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def authenticate
-    authenticate_or_request_with_http_token do |token, options|
-      token == ENV.fetch('API_SECRET')
+    unless ENV["API_SECRET"].blank?
+      authenticate_or_request_with_http_token do |token, options|
+        token == ENV.fetch("API_SECRET")
+      end
     end
   end
 end


### PR DESCRIPTION
We want to let people use staging or demo instance for building apps.

By not having a token for few instance it's easy to use JSON api.