### PR TITLE
Add V3 conferences route

### DIFF
--- a/app/controllers/api/v2/conferences_controller.rb
+++ b/app/controllers/api/v2/conferences_controller.rb
@@ -9,7 +9,7 @@ class Api::V2::ConferencesController < Api::BaseController
     @conferences || Conference.tagged_with(
       search_params,
       any: true
-    ).upcoming
+    ).v2_conferences
   end
 
   def search_params

--- a/app/controllers/api/v3/conferences_controller.rb
+++ b/app/controllers/api/v3/conferences_controller.rb
@@ -1,0 +1,10 @@
+class Api::V3::ConferencesController < Api::V2::ConferencesController
+  private
+
+  def conferences
+    @conferences || Conference.tagged_with(
+      search_params,
+      any: true
+    ).upcoming
+  end
+end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -17,6 +17,11 @@ class Conference < ActiveRecord::Base
     where("start_date >= ?", Date.today).order("start_date")
   end
 
+  # Specific bug in iOS version 1.2 with deleting old conferences from list
+  def self.v2_conferences
+    where("start_date >= ?", Date.parse("14 Oct 2015")).order("start_date")
+  end
+
   def self.past
     where("start_date < ?", Date.today).order("start_date DESC")
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Rails.application.routes.draw do
     namespace :v2 do
       resources :conferences, only: [:index]
     end
+
+    namespace :v3 do
+      resources :conferences, only: [:index]
+    end
   end
 
   get "privacy" => "high_voltage/pages#show", id: "home"

--- a/spec/requests/api/v2/conferences_spec.rb
+++ b/spec/requests/api/v2/conferences_spec.rb
@@ -41,15 +41,20 @@ describe "/api/v2/conferences" do
         expect(json.count).to eq(2)
       end
 
-      it "will render upcoming conferences" do
-        upcoming_ruby_conference = create(:conference, :ruby, :upcoming)
+      it "will render only v2 conferences" do
+        ruby_conference = create(
+          :conference,
+          :ruby,
+          start_date: Date.parse("14 Oct 2015")
+        )
+        create(:conference, :ruby, start_date: Date.parse("13 Oct 2015"))
         create(:conference, :ruby, :past)
 
         get "/api/v2/conferences", { tags: "ruby" }, token_auth
 
         expect(json.count).to eq(1)
-        expect(json.first["id"]).to eq(upcoming_ruby_conference.id)
-        expect(json.first["name"]).to eq(upcoming_ruby_conference.name)
+        expect(json.first["id"]).to eq(ruby_conference.id)
+        expect(json.first["name"]).to eq(ruby_conference.name)
       end
     end
   end

--- a/spec/requests/api/v3/conferences_spec.rb
+++ b/spec/requests/api/v3/conferences_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe "/api/v3/conferences" do
+  describe "get conferences" do
+    context "for JSON" do
+      it "will render all required keys for v3" do
+        create(:conference, :ruby)
+
+        get "/api/v3/conferences", { tags: "ruby" }, token_auth
+
+        expect(json.count).to eq(1)
+        expect(json.first.keys).to eq(
+          %w(id name location description twitter_username start_date end_date website when logos latitude longitude cfp_end_at cfp_status)
+        )
+      end
+
+      it "will render conferences tagged with given tags" do
+        create(:conference, :ruby)
+        create(:conference, :javascript)
+        design_conference = create(:conference, :design)
+
+        get "/api/v3/conferences", { tags: "ruby,javascript" }, token_auth
+
+        ids = json.map { |key| key["id"] }
+        expect(ids).not_to include(design_conference.id)
+        expect(json.count).to eq(2)
+      end
+
+      it "will render upcoming conferences" do
+        ruby_conference = create(:conference, :ruby, :upcoming)
+        create(:conference, :ruby, :past)
+
+        get "/api/v3/conferences", { tags: "ruby" }, token_auth
+
+        expect(json.count).to eq(1)
+        expect(json.first["id"]).to eq(ruby_conference.id)
+        expect(json.first["name"]).to eq(ruby_conference.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
A bug introduced in iOS app 1.2 version that we cannot delete
conferences from list so locking V2 api to just render conferences after
14Oct2015 will not make app crash.

Will use V3 for newer version of apps